### PR TITLE
Fix cygwin build with 64bit long double

### DIFF
--- a/newlib/Makefile.in
+++ b/newlib/Makefile.in
@@ -975,7 +975,7 @@ check_PROGRAMS =
 @HAVE_FPMATH_H_TRUE@am__append_142 = 
 @HAVE_FPMATH_H_TRUE@am__append_143 = 
 @HAVE_LIBM_MACHINE_AARCH64_TRUE@am__append_144 = $(libm_machine_aarch64_src)
-@HAVE_LIBM_MACHINE_AARCH64_TRUE@@HAVE_LONG_DOUBLE_TRUE@am__append_145 = $(libm_ld128_lsrc)
+@HAVE_FPMATH_H_TRUE@@HAVE_LIBM_MACHINE_AARCH64_TRUE@@HAVE_LONG_DOUBLE_TRUE@am__append_145 = $(libm_ld128_lsrc)
 @HAVE_LIBM_MACHINE_AARCH64_TRUE@am__append_146 = 
 @HAVE_LIBM_MACHINE_AARCH64_TRUE@am__append_147 = 
 @HAVE_LIBM_MACHINE_AMDGCN_TRUE@am__append_148 = $(libm_machine_amdgcn_src)
@@ -3261,6 +3261,32 @@ am__objects_160 = libm/fenv/libm_a-feclearexcept.$(OBJEXT) \
 @HAVE_LIBM_MACHINE_AARCH64_TRUE@	libm/machine/aarch64/libm_a-fetestexcept.$(OBJEXT) \
 @HAVE_LIBM_MACHINE_AARCH64_TRUE@	libm/machine/aarch64/libm_a-feupdateenv.$(OBJEXT)
 @HAVE_LIBM_MACHINE_AARCH64_TRUE@am__objects_162 = $(am__objects_161)
+@HAVE_FPMATH_H_FALSE@@HAVE_LIBM_MACHINE_RISCV_TRUE@am__objects_163 = libm/ld128/libm_a-e_powl.$(OBJEXT) \
+@HAVE_FPMATH_H_FALSE@@HAVE_LIBM_MACHINE_RISCV_TRUE@	libm/ld128/libm_a-s_erfl.$(OBJEXT) \
+@HAVE_FPMATH_H_FALSE@@HAVE_LIBM_MACHINE_RISCV_TRUE@	libm/ld128/libm_a-s_exp2l.$(OBJEXT) \
+@HAVE_FPMATH_H_FALSE@@HAVE_LIBM_MACHINE_RISCV_TRUE@	libm/ld128/libm_a-s_expl.$(OBJEXT) \
+@HAVE_FPMATH_H_FALSE@@HAVE_LIBM_MACHINE_RISCV_TRUE@	libm/ld128/libm_a-s_logl.$(OBJEXT) \
+@HAVE_FPMATH_H_FALSE@@HAVE_LIBM_MACHINE_RISCV_TRUE@	libm/ld128/libm_a-b_tgammal.$(OBJEXT) \
+@HAVE_FPMATH_H_FALSE@@HAVE_LIBM_MACHINE_RISCV_TRUE@	libm/ld128/libm_a-invtrig.$(OBJEXT) \
+@HAVE_FPMATH_H_FALSE@@HAVE_LIBM_MACHINE_RISCV_TRUE@	libm/ld128/libm_a-e_lgammal_r.$(OBJEXT) \
+@HAVE_FPMATH_H_FALSE@@HAVE_LIBM_MACHINE_RISCV_TRUE@	libm/ld128/libm_a-k_cosl.$(OBJEXT) \
+@HAVE_FPMATH_H_FALSE@@HAVE_LIBM_MACHINE_RISCV_TRUE@	libm/ld128/libm_a-k_sinl.$(OBJEXT) \
+@HAVE_FPMATH_H_FALSE@@HAVE_LIBM_MACHINE_RISCV_TRUE@	libm/ld128/libm_a-k_tanl.$(OBJEXT) \
+@HAVE_FPMATH_H_FALSE@@HAVE_LIBM_MACHINE_RISCV_TRUE@	libm/ld128/libm_a-s_sinpil.$(OBJEXT) \
+@HAVE_FPMATH_H_FALSE@@HAVE_LIBM_MACHINE_RISCV_TRUE@	libm/ld128/libm_a-s_cospil.$(OBJEXT)
+@HAVE_FPMATH_H_TRUE@@HAVE_LIBM_MACHINE_AARCH64_TRUE@am__objects_163 = libm/ld128/libm_a-e_powl.$(OBJEXT) \
+@HAVE_FPMATH_H_TRUE@@HAVE_LIBM_MACHINE_AARCH64_TRUE@	libm/ld128/libm_a-s_erfl.$(OBJEXT) \
+@HAVE_FPMATH_H_TRUE@@HAVE_LIBM_MACHINE_AARCH64_TRUE@	libm/ld128/libm_a-s_exp2l.$(OBJEXT) \
+@HAVE_FPMATH_H_TRUE@@HAVE_LIBM_MACHINE_AARCH64_TRUE@	libm/ld128/libm_a-s_expl.$(OBJEXT) \
+@HAVE_FPMATH_H_TRUE@@HAVE_LIBM_MACHINE_AARCH64_TRUE@	libm/ld128/libm_a-s_logl.$(OBJEXT) \
+@HAVE_FPMATH_H_TRUE@@HAVE_LIBM_MACHINE_AARCH64_TRUE@	libm/ld128/libm_a-b_tgammal.$(OBJEXT) \
+@HAVE_FPMATH_H_TRUE@@HAVE_LIBM_MACHINE_AARCH64_TRUE@	libm/ld128/libm_a-invtrig.$(OBJEXT) \
+@HAVE_FPMATH_H_TRUE@@HAVE_LIBM_MACHINE_AARCH64_TRUE@	libm/ld128/libm_a-e_lgammal_r.$(OBJEXT) \
+@HAVE_FPMATH_H_TRUE@@HAVE_LIBM_MACHINE_AARCH64_TRUE@	libm/ld128/libm_a-k_cosl.$(OBJEXT) \
+@HAVE_FPMATH_H_TRUE@@HAVE_LIBM_MACHINE_AARCH64_TRUE@	libm/ld128/libm_a-k_sinl.$(OBJEXT) \
+@HAVE_FPMATH_H_TRUE@@HAVE_LIBM_MACHINE_AARCH64_TRUE@	libm/ld128/libm_a-k_tanl.$(OBJEXT) \
+@HAVE_FPMATH_H_TRUE@@HAVE_LIBM_MACHINE_AARCH64_TRUE@	libm/ld128/libm_a-s_sinpil.$(OBJEXT) \
+@HAVE_FPMATH_H_TRUE@@HAVE_LIBM_MACHINE_AARCH64_TRUE@	libm/ld128/libm_a-s_cospil.$(OBJEXT)
 @HAVE_LIBM_MACHINE_AARCH64_FALSE@@HAVE_LIBM_MACHINE_RISCV_TRUE@am__objects_163 = libm/ld128/libm_a-e_powl.$(OBJEXT) \
 @HAVE_LIBM_MACHINE_AARCH64_FALSE@@HAVE_LIBM_MACHINE_RISCV_TRUE@	libm/ld128/libm_a-s_erfl.$(OBJEXT) \
 @HAVE_LIBM_MACHINE_AARCH64_FALSE@@HAVE_LIBM_MACHINE_RISCV_TRUE@	libm/ld128/libm_a-s_exp2l.$(OBJEXT) \
@@ -3274,20 +3300,7 @@ am__objects_160 = libm/fenv/libm_a-feclearexcept.$(OBJEXT) \
 @HAVE_LIBM_MACHINE_AARCH64_FALSE@@HAVE_LIBM_MACHINE_RISCV_TRUE@	libm/ld128/libm_a-k_tanl.$(OBJEXT) \
 @HAVE_LIBM_MACHINE_AARCH64_FALSE@@HAVE_LIBM_MACHINE_RISCV_TRUE@	libm/ld128/libm_a-s_sinpil.$(OBJEXT) \
 @HAVE_LIBM_MACHINE_AARCH64_FALSE@@HAVE_LIBM_MACHINE_RISCV_TRUE@	libm/ld128/libm_a-s_cospil.$(OBJEXT)
-@HAVE_LIBM_MACHINE_AARCH64_TRUE@am__objects_163 = libm/ld128/libm_a-e_powl.$(OBJEXT) \
-@HAVE_LIBM_MACHINE_AARCH64_TRUE@	libm/ld128/libm_a-s_erfl.$(OBJEXT) \
-@HAVE_LIBM_MACHINE_AARCH64_TRUE@	libm/ld128/libm_a-s_exp2l.$(OBJEXT) \
-@HAVE_LIBM_MACHINE_AARCH64_TRUE@	libm/ld128/libm_a-s_expl.$(OBJEXT) \
-@HAVE_LIBM_MACHINE_AARCH64_TRUE@	libm/ld128/libm_a-s_logl.$(OBJEXT) \
-@HAVE_LIBM_MACHINE_AARCH64_TRUE@	libm/ld128/libm_a-b_tgammal.$(OBJEXT) \
-@HAVE_LIBM_MACHINE_AARCH64_TRUE@	libm/ld128/libm_a-invtrig.$(OBJEXT) \
-@HAVE_LIBM_MACHINE_AARCH64_TRUE@	libm/ld128/libm_a-e_lgammal_r.$(OBJEXT) \
-@HAVE_LIBM_MACHINE_AARCH64_TRUE@	libm/ld128/libm_a-k_cosl.$(OBJEXT) \
-@HAVE_LIBM_MACHINE_AARCH64_TRUE@	libm/ld128/libm_a-k_sinl.$(OBJEXT) \
-@HAVE_LIBM_MACHINE_AARCH64_TRUE@	libm/ld128/libm_a-k_tanl.$(OBJEXT) \
-@HAVE_LIBM_MACHINE_AARCH64_TRUE@	libm/ld128/libm_a-s_sinpil.$(OBJEXT) \
-@HAVE_LIBM_MACHINE_AARCH64_TRUE@	libm/ld128/libm_a-s_cospil.$(OBJEXT)
-@HAVE_LIBM_MACHINE_AARCH64_TRUE@@HAVE_LONG_DOUBLE_TRUE@am__objects_164 = $(am__objects_163)
+@HAVE_FPMATH_H_TRUE@@HAVE_LIBM_MACHINE_AARCH64_TRUE@@HAVE_LONG_DOUBLE_TRUE@am__objects_164 = $(am__objects_163)
 @HAVE_LIBM_MACHINE_AMDGCN_TRUE@am__objects_165 = libm/machine/amdgcn/libm_a-v64_mathcnst.$(OBJEXT) \
 @HAVE_LIBM_MACHINE_AMDGCN_TRUE@	libm/machine/amdgcn/libm_a-v64_reent.$(OBJEXT) \
 @HAVE_LIBM_MACHINE_AMDGCN_TRUE@	libm/machine/amdgcn/libm_a-v64df_acos.$(OBJEXT) \
@@ -5096,11 +5109,11 @@ libm_test_test_LDADD = $(CRT0) libm.a libc.a
 @HAVE_LIBM_MACHINE_AARCH64_TRUE@	libm/machine/aarch64/fetestexcept.c \
 @HAVE_LIBM_MACHINE_AARCH64_TRUE@	libm/machine/aarch64/feupdateenv.c
 
-@HAVE_LIBM_MACHINE_AARCH64_TRUE@libm_ld128_lsrc = \
-@HAVE_LIBM_MACHINE_AARCH64_TRUE@	libm/ld128/e_powl.c libm/ld128/s_erfl.c libm/ld128/s_exp2l.c libm/ld128/s_expl.c \
-@HAVE_LIBM_MACHINE_AARCH64_TRUE@	libm/ld128/s_logl.c libm/ld128/b_tgammal.c libm/ld128/invtrig.c \
-@HAVE_LIBM_MACHINE_AARCH64_TRUE@	libm/ld128/e_lgammal_r.c libm/ld128/k_cosl.c libm/ld128/k_sinl.c \
-@HAVE_LIBM_MACHINE_AARCH64_TRUE@	libm/ld128/k_tanl.c libm/ld128/s_sinpil.c libm/ld128/s_cospil.c
+@HAVE_FPMATH_H_TRUE@@HAVE_LIBM_MACHINE_AARCH64_TRUE@libm_ld128_lsrc = \
+@HAVE_FPMATH_H_TRUE@@HAVE_LIBM_MACHINE_AARCH64_TRUE@	libm/ld128/e_powl.c libm/ld128/s_erfl.c libm/ld128/s_exp2l.c libm/ld128/s_expl.c \
+@HAVE_FPMATH_H_TRUE@@HAVE_LIBM_MACHINE_AARCH64_TRUE@	libm/ld128/s_logl.c libm/ld128/b_tgammal.c libm/ld128/invtrig.c \
+@HAVE_FPMATH_H_TRUE@@HAVE_LIBM_MACHINE_AARCH64_TRUE@	libm/ld128/e_lgammal_r.c libm/ld128/k_cosl.c libm/ld128/k_sinl.c \
+@HAVE_FPMATH_H_TRUE@@HAVE_LIBM_MACHINE_AARCH64_TRUE@	libm/ld128/k_tanl.c libm/ld128/s_sinpil.c libm/ld128/s_cospil.c
 
 @HAVE_LIBM_MACHINE_RISCV_TRUE@libm_ld128_lsrc = \
 @HAVE_LIBM_MACHINE_RISCV_TRUE@	libm/ld128/e_powl.c libm/ld128/s_erfl.c libm/ld128/s_exp2l.c libm/ld128/s_expl.c \
@@ -5108,7 +5121,7 @@ libm_test_test_LDADD = $(CRT0) libm.a libc.a
 @HAVE_LIBM_MACHINE_RISCV_TRUE@	libm/ld128/e_lgammal_r.c libm/ld128/k_cosl.c libm/ld128/k_sinl.c \
 @HAVE_LIBM_MACHINE_RISCV_TRUE@	libm/ld128/k_tanl.c libm/ld128/s_sinpil.c libm/ld128/s_cospil.c
 
-@HAVE_LIBM_MACHINE_AARCH64_TRUE@libm_a_CFLAGS_libm_ld128 = -fbuiltin -fno-math-errno
+@HAVE_FPMATH_H_TRUE@@HAVE_LIBM_MACHINE_AARCH64_TRUE@libm_a_CFLAGS_libm_ld128 = -fbuiltin -fno-math-errno
 @HAVE_LIBM_MACHINE_RISCV_TRUE@libm_a_CFLAGS_libm_ld128 = -fbuiltin -fno-math-errno
 @HAVE_LIBM_MACHINE_AMDGCN_TRUE@libm_machine_amdgcn_src = \
 @HAVE_LIBM_MACHINE_AMDGCN_TRUE@	libm/machine/amdgcn/v64_mathcnst.c \

--- a/newlib/configure
+++ b/newlib/configure
@@ -6158,7 +6158,15 @@ else
 fi
 
 
- if test -r "${srcdir}/libc/machine/${machine_dir}/machine/_fpmath.h"; then
+case $host in
+  aarch64-*-mingw* | aarch64-*-cygwin*)
+    IS_AARCH64_WINDOWS=yes ;;
+  *)
+    IS_AARCH64_WINDOWS=no ;;
+esac
+
+
+ if (test -r "${srcdir}/libc/machine/${machine_dir}/machine/_fpmath.h") && (test $IS_AARCH64_WINDOWS = no); then
   HAVE_FPMATH_H_TRUE=
   HAVE_FPMATH_H_FALSE='#'
 else

--- a/newlib/libc/acinclude.m4
+++ b/newlib/libc/acinclude.m4
@@ -63,7 +63,14 @@ m4_foreach_w([MACHINE], [
   z8k
 ], [AM_CONDITIONAL([HAVE_LIBC_MACHINE_]m4_toupper(MACHINE), test "${machine_dir}" = MACHINE)])
 
-AM_CONDITIONAL(HAVE_FPMATH_H, test -r "${srcdir}/libc/machine/${machine_dir}/machine/_fpmath.h")
+case $host in
+  aarch64-*-mingw* | aarch64-*-cygwin*)
+    IS_AARCH64_WINDOWS=yes ;;
+  *)
+    IS_AARCH64_WINDOWS=no ;;
+esac
+
+AM_CONDITIONAL(HAVE_FPMATH_H, (test -r "${srcdir}/libc/machine/${machine_dir}/machine/_fpmath.h") && (test $IS_AARCH64_WINDOWS = no))
 
 
 AM_CONDITIONAL(MACH_ADD_SETJMP, test "x$mach_add_setjmp" = "xtrue")

--- a/newlib/libm/Makefile.inc
+++ b/newlib/libm/Makefile.inc
@@ -55,8 +55,10 @@ include %D%/test/Makefile.inc
 
 if HAVE_LIBM_MACHINE_AARCH64
 include %D%/machine/aarch64/Makefile.inc
+if HAVE_FPMATH_H
 include %D%/ld128/Makefile.inc
-endif
+endif # HAVE_FPMATH_H
+endif # HAVE_LIBM_MACHINE_AARCH64
 if HAVE_LIBM_MACHINE_AMDGCN
 include %D%/machine/amdgcn/Makefile.inc
 endif

--- a/winsup/cygwin/math/cephes_mconf.h
+++ b/winsup/cygwin/math/cephes_mconf.h
@@ -66,7 +66,7 @@ extern double __QNAN;
 #endif
 
 /*long double*/
-#if defined(__arm__) || defined(_ARM_)
+#if defined(__arm__) || defined(_ARM_) || defined(__aarch64__)
 #define MAXNUML	1.7976931348623158E308
 #define MAXLOGL	7.09782712893383996843E2
 #define MINLOGL	-7.08396418532264106224E2
@@ -84,7 +84,7 @@ extern double __QNAN;
 #define PIL	3.1415926535897932384626L
 #define PIO2L	1.5707963267948966192313L
 #define PIO4L	7.8539816339744830961566E-1L
-#endif /* defined(__arm__) || defined(_ARM_) */
+#endif /* defined(__arm__) || defined(_ARM_) || defined(__aarch64__) */
 
 #define isfinitel isfinite
 #define isinfl isinf

--- a/winsup/cygwin/math/lgammal.c
+++ b/winsup/cygwin/math/lgammal.c
@@ -198,11 +198,11 @@ static uLD C[] = {
 
 /* log( sqrt( 2*pi ) ) */
 static const long double LS2PI  =  0.91893853320467274178L;
-#if defined(__arm__) || defined(_ARM_)
+#if defined(__arm__) || defined(_ARM_) || defined(__aarch64__)
 #define MAXLGM 2.035093e36
 #else
 #define MAXLGM 1.04848146839019521116e+4928L
-#endif /* defined(__arm__) || defined(_ARM_) */
+#endif /* defined(__arm__) || defined(_ARM_) || defined(__aarch64__) */
 
 /* Logarithm of gamma function */
 /* Reentrant version */

--- a/winsup/cygwin/math/nextafterl.c
+++ b/winsup/cygwin/math/nextafterl.c
@@ -16,6 +16,9 @@
 long double
 nextafterl (long double x, long double y)
 {
+# if defined(__aarch64__)
+  return (long double) nexttoward (x, y);
+# else
   union {
       long double ld;
       struct {
@@ -63,6 +66,7 @@ nextafterl (long double x, long double y)
     u.parts.mantissa |=  normal_bit;
 
   return u.ld;
+# endif /* defined(__aarch64__) */
 }
 
 /* nexttowardl is the same function with a different name.  */

--- a/winsup/cygwin/math/rintl.c
+++ b/winsup/cygwin/math/rintl.c
@@ -9,7 +9,7 @@ long double rintl (long double x) {
   long double retval = 0.0L;
 #if defined(_AMD64_) || defined(__x86_64__) || defined(_X86_) || defined(__i386__)
   __asm__ __volatile__ ("frndint;": "=t" (retval) : "0" (x));
-#elif defined(__arm__) || defined(_ARM_)
+#elif defined(__arm__) || defined(_ARM_) || defined(__aarch64__)
     retval = rint(x);
 #endif
   return retval;


### PR DESCRIPTION
Changes in Cygwin needed for https://github.com/Windows-on-ARM-Experiments/gcc-woarm64/pull/3

Disables compiling long double functions in `newlib/libm`. [This patch series](https://inbox.sourceware.org/newlib/CAF9ehCUVsE=Fx_seO7RDMKUii4QujwHDFxxZADHCN0EfnDaH5A@mail.gmail.com/T/#t) added `long double` functions from FreeBSD's `libm` into Cygwin's `newlib/libm`. It supports only 80bit and 128bit `long double` but the way it was added in the mentioned patch series, it always compiles for `aarch64` targets. This code in `newlib/libm` is newer used for Cygwin targets because Cygwin implements `long double` functions itself in `winsup/cygwin/math`.

Adds some missing guards for `__aarch64__`.

Testing pipeline: https://github.com/Windows-on-ARM-Experiments/mingw-woarm64-build/actions/runs/12912580048