### PR TITLE
Add a temporary workaround to handle SIGFE as NOSIGFE

### DIFF
--- a/winsup/cygwin/cygwin.din
+++ b/winsup/cygwin/cygwin.din
@@ -1208,7 +1208,7 @@ putc_unlocked SIGFE
 putchar SIGFE
 putchar_unlocked SIGFE
 putenv SIGFE
-puts NOSIGFE
+puts SIGFE
 pututline SIGFE
 pututxline SIGFE
 putw SIGFE

--- a/winsup/cygwin/scripts/gendef
+++ b/winsup/cygwin/scripts/gendef
@@ -53,14 +53,14 @@ for (@in) {
 	}
     } else {
 	my ($func, $sigfe) = m%^\s*(\S+)(?:\s+((?:NO)?SIGFE(?:_MAYBE)?))?$%o;
-	if (defined($sigfe) && $sigfe =~ /^NO/o) {
+	# if (defined($sigfe) && $sigfe =~ /^NO/o) {
 	    $_ = $func;
-	} else {
-	    $sigfe ||= 'sigfe';
-	    $_ = '_' . lc($sigfe) . '_' . $func;
-	    $sigfe{$func} = $_;
-	    $_ = $func . ' = ' . $_;
-	}
+	# } else {
+	#     $sigfe ||= 'sigfe';
+	#     $_ = '_' . lc($sigfe) . '_' . $func;
+	#     $sigfe{$func} = $_;
+	#     $_ = $func . ' = ' . $_;
+	# }
     }
     s/(\S)\s+(\S)/$1 $2/go;
     s/(\S)\s+$/$1/o;


### PR DESCRIPTION
Validated by
https://github.com/Windows-on-ARM-Experiments/mingw-woarm64-build/actions/runs/12995166412