### PR TITLE
Fix `cygtls::*` regression

### DIFF
--- a/winsup/cygwin/local_includes/cygtls.h
+++ b/winsup/cygwin/local_includes/cygtls.h
@@ -225,22 +225,21 @@ public: /* Do NOT remove this public: line, it's a marker for gentls_offsets. */
   int call_signal_handler ();
   void remove_wq (DWORD);
   void fixup_after_fork ();
-#if !defined(__aarch64__)
   void lock ()
   {
     while (InterlockedExchange (&stacklock, 1))
       {
 #if defined(__x86_64__)
 	__asm__ ("pause");
+#elif defined(__aarch64__)
+	// TODO: Validate this.
+	__asm__ ("yield");
 #else
 #error unimplemented for this target
 #endif
 	Sleep (0);
       }
   }
-#else
-  void lock ();
-#endif
   void unlock () { stacklock = 0; }
   bool locked () { return !!stacklock; }
   HANDLE get_signal_arrived (bool wait_for_lock = true)

--- a/winsup/cygwin/scripts/gendef
+++ b/winsup/cygwin/scripts/gendef
@@ -415,30 +415,6 @@ _ZN7_cygtls3popEv:
 	ret
 	.seh_endproc
 
-# _cygtls::lock
-	.global _ZN7_cygtls4lockEv
-	.seh_proc _ZN7_cygtls4lockEv
-_ZN7_cygtls4lockEv:
-	.seh_endprologue
-	ret
-	.seh_endproc
-
-# _cygtls::unlock
-	.global _ZN7_cygtls6unlockEv
-	.seh_proc _ZN7_cygtls6unlockEv
-_ZN7_cygtls6unlockEv:
-	.seh_endprologue
-	ret
-	.seh_endproc
-
-# _cygtls::locked
-	.global _ZN7_cygtls6lockedEv
-	.seh_proc _ZN7_cygtls6lockedEv
-_ZN7_cygtls6lockedEv:
-	.seh_endprologue
-	ret
-	.seh_endproc
-
 	.seh_proc stabilize_sig_stack
 stabilize_sig_stack:
 	.seh_endprologue


### PR DESCRIPTION
Noticed this regression between the old workarkounds in [winsup/cygwin/scripts/gendef](https://github.com/Windows-on-ARM-Experiments/newlib-cygwin/compare/woarm64...woarm64-fix#diff-6b3bd4c0b2499d377fc509b875397cd30ee9f3ae3738de0675cb8b17ffc993fc) and how it has changed meanwhile when building debug version of Cygwin. For some reson `-O2` build was not hitting it. It was introduced during rebase collisions resolution.

Validated by https://github.com/Windows-on-ARM-Experiments/mingw-woarm64-build/actions/runs/15087682793