### PR TITLE
Fix SIGFE wrapper and revert malloc to original code with aarch64 port

### DIFF
--- a/winsup/cygwin/mm/malloc_wrapper.cc
+++ b/winsup/cygwin/mm/malloc_wrapper.cc
@@ -334,7 +334,7 @@ malloc_init ()
 	 address from user_data.  */
       use_internal = user_data->malloc == malloc
 		     || import_address ((void *) user_data->malloc)
-			== malloc;
+			== &_sigfe_malloc;
       malloc_printf ("using %s malloc", use_internal ? "internal" : "external");
       internal_malloc_determined = true;
     }

--- a/winsup/cygwin/scripts/gendef
+++ b/winsup/cygwin/scripts/gendef
@@ -53,14 +53,14 @@ for (@in) {
 	}
     } else {
 	my ($func, $sigfe) = m%^\s*(\S+)(?:\s+((?:NO)?SIGFE(?:_MAYBE)?))?$%o;
-	# if (defined($sigfe) && $sigfe =~ /^NO/o) {
+	if (defined($sigfe) && $sigfe =~ /^NO/o) {
 	    $_ = $func;
-	# } else {
-	#     $sigfe ||= 'sigfe';
-	#     $_ = '_' . lc($sigfe) . '_' . $func;
-	#     $sigfe{$func} = $_;
-	#     $_ = $func . ' = ' . $_;
-	# }
+	} else {
+	    $sigfe ||= 'sigfe';
+	    $_ = '_' . lc($sigfe) . '_' . $func;
+	    $sigfe{$func} = $_;
+	    $_ = $func . ' = ' . $_;
+	}
     }
     s/(\S)\s+(\S)/$1 $2/go;
     s/(\S)\s+$/$1/o;
@@ -117,13 +117,15 @@ EOF
 	.global $fe
 	.seh_proc $fe
 $fe:
-	adrp x17, $func
-	str x17, [sp, #-16]!
-	.seh_pushreg x17
+	sub sp, sp, 16
+	.seh_stackalloc 16
 	.seh_endprologue
-	adr x16, $sigfe_func
-	ldr x16, [x16]
-	br x16
+	adrp x9, $func
+	add x9, x9, :lo12:$func
+	str x9, [sp, 0]
+	adrp x9, $sigfe_func
+	add x9, x9, :lo12:$sigfe_func
+	br x9
 	.seh_endproc
 EOF
     }
@@ -384,6 +386,8 @@ _sigfe_maybe:					# stack is aligned on entry!
 	.seh_proc _sigfe
 _sigfe:						# stack is aligned on entry!
 	.seh_endprologue
+	ldr x9, [sp], #16
+	br x9
 	.seh_endproc
 
 	.global _sigbe


### PR DESCRIPTION
SIGFE wrapper has been fixed as part of signal porting to Arm64. It will be extended to signal handling implementation in a separate PR.

Validate by
https://github.com/Windows-on-ARM-Experiments/mingw-woarm64-build/actions/runs/13110900942