### PR TITLE
aarch64: Math functions Implementations in C

### DIFF
--- a/winsup/cygwin/math/asinl.c
+++ b/winsup/cygwin/math/asinl.c
@@ -10,6 +10,10 @@
  */
 
 /* asin = atan (x / sqrt(1 - x^2)) */
+#if defined(__aarch64__)
+#include <math.h>
+#endif
+
 long double asinl (long double x);
 
 long double asinl (long double x)
@@ -26,8 +30,8 @@ long double asinl (long double x)
 	"fpatan"
 	: "=t" (res) : "0" (x) : "st(1)");
 #elif defined(__aarch64__)
-    // TODO
-    res = 0.0;
+  // TODO: Complete AArch64 assembly implementation
+  res = atan2l (x, sqrtl (1 - x * x));
 #endif
   return res;
 }

--- a/winsup/cygwin/math/atan2l.c
+++ b/winsup/cygwin/math/atan2l.c
@@ -3,6 +3,10 @@
  * This file is part of the mingw-w64 runtime package.
  * No warranty is given; refer to the file DISCLAIMER.PD within this package.
  */
+#if defined(__aarch64__)
+#include <math.h>
+#endif
+
 long double atan2l (long double y, long double x);
 
 long double
@@ -12,8 +16,8 @@ atan2l (long double y, long double x)
 #if defined(__x86_64__)
   asm volatile ("fpatan" : "=t" (res) : "u" (y), "0" (x) : "st(1)");
 #elif defined(__aarch64__)
-    // TODO
-    res = 0.0;
+  // TODO: Complete AArch64 assembly implementation
+  res = atan2 (y, x);
 #endif
   return res;
 }

--- a/winsup/cygwin/math/atanl.c
+++ b/winsup/cygwin/math/atanl.c
@@ -3,6 +3,10 @@
  * This file is part of the mingw-w64 runtime package.
  * No warranty is given; refer to the file DISCLAIMER.PD within this package.
  */
+#if defined(__aarch64__)
+#include <math.h>
+#endif
+
 long double atanl (long double x);
 
 long double
@@ -15,8 +19,8 @@ atanl (long double x)
        "fpatan"
        : "=t" (res) : "0" (x));
 #elif defined(__aarch64__)
-    // TODO
-    res = 0.0;
+  // TODO: Complete AArch64 assembly implementation
+  res = atan (x);
 #endif
   return res;
 }

--- a/winsup/cygwin/math/cosl_internal.S
+++ b/winsup/cygwin/math/cosl_internal.S
@@ -51,7 +51,13 @@ __MINGW_USYMBOL(__cosl_internal):
 	fstp	%st(1)
 	fcos
 	ret
+#elif defined(__aarch64__)
+	// TODO: Complete AArch64 assembly implementation
+	stp q0, q1, [sp, -32]!
+	bl cos
+	ldp q0, q1, [sp], 32
+	ret
 #else
-  // TODO
+  .error "Not supported on your architecture yet "
 #endif
 

--- a/winsup/cygwin/math/cossin.c
+++ b/winsup/cygwin/math/cossin.c
@@ -3,6 +3,9 @@
  * This file is part of the mingw-w64 runtime package.
  * No warranty is given; refer to the file DISCLAIMER.PD within this package.
  */
+#if defined(__aarch64__)
+#include <math.h>
+#endif
 
 void sincos (double __x, double *p_sin, double *p_cos);
 void sincosl (long double __x, long double *p_sin, long double *p_cos);
@@ -28,9 +31,9 @@ void sincos (double __x, double *p_sin, double *p_cos)
     "fsincos\n\t"
     "1:" : "=t" (c), "=u" (s) : "0" (__x));
 #elif defined(__aarch64__)
-  // TODO
-  c = 0.0;
-  s = 0.0;
+  // TODO: Complete AArch64 assembly implementation
+  c = cos (__x);
+  s = sin (__x);
 #endif
   *p_sin = (double) s;
   *p_cos = (double) c;
@@ -56,9 +59,9 @@ void sincosf (float __x, float *p_sin, float *p_cos)
     "fsincos\n\t"
     "1:" : "=t" (c), "=u" (s) : "0" (__x));
 #elif defined(__aarch64__)
-  // TODO
-  c = 0.0;
-  s = 0.0;
+  // TODO: Complete AArch64 assembly implementation
+  c = cosf (__x);
+  s = sinf (__x);
 #endif
   *p_sin = (float) s;
   *p_cos = (float) c;
@@ -84,9 +87,9 @@ void sincosl (long double __x, long double *p_sin, long double *p_cos)
     "fsincos\n\t"
     "1:" : "=t" (c), "=u" (s) : "0" (__x));
 #elif defined(__aarch64__)
-  // TODO
-  c = 0.0;
-  s = 0.0;
+  // TODO: Complete AArch64 assembly implementation
+  c = cosl (__x);
+  s = sinl (__x);
 #endif
   *p_sin = s;
   *p_cos = c;

--- a/winsup/cygwin/math/exp.def.h
+++ b/winsup/cygwin/math/exp.def.h
@@ -103,8 +103,12 @@ __expl_internal (long double x)
        "fstp	%%st(1)\n\t"    /* 0  */
        : "=t" (res) : "0" (x), "m" (c0), "m" (c1) : "ax", "dx");
 #elif defined(__aarch64__)
-  // TODO
-  res = 0.0 * c0 * c1;
+  // TODO: Complete AArch64 assembly implementation
+  long double y = x * c0;
+  long double i;
+  long double f = modfl (y, &i);
+  long double z = 1.0L + f + (c1 * f);
+  res = ldexpl (z, (int)i);
 #endif
   return res;
 }

--- a/winsup/cygwin/math/exp2l.S
+++ b/winsup/cygwin/math/exp2l.S
@@ -89,6 +89,12 @@ __MINGW_USYMBOL(exp2l):
 	fstp	%st
 	fldz				/* Set result to 0.  */
 2:	ret
+#elif defined(__aarch64__)
+	// TODO: Complete AArch64 assembly implementation
+	stp q0, q0, [sp, -16]!
+	bl exp2
+	ldp q0, q0, [sp], 16
+	ret
 #else
-  // TODO
+	.error "Not supported on your architecture yet"
 #endif

--- a/winsup/cygwin/math/expm1.def.h
+++ b/winsup/cygwin/math/expm1.def.h
@@ -68,8 +68,8 @@ __FLT_ABI(expm1) (__FLT_TYPE x)
 #if defined(_x86_64__)
       __asm__ __volatile__ ("f2xm1" : "=t" (x) : "0" (x));
 #elif defined(__aarch64__)
-      // TODO 
-      x = 0.0;
+      // TODO: Complete AArch64 assembly implementation
+      x = exp2 (x) - 1.0;
 #endif
       return x;
     }

--- a/winsup/cygwin/math/fastmath.h
+++ b/winsup/cygwin/math/fastmath.h
@@ -29,8 +29,7 @@ static __inline__ long double __fast_sqrtl (long double x)
 #if defined(__x86_64__)
   asm __volatile__ ("fsqrt" : "=t" (res) : "0" (x));
 #elif defined(__aarch64__)
-  // TODO
-  res = 0.0;
+  asm volatile ("fsqrt %d0, %d1" : "=w"(res) : "w"(x));
 #endif
   return res;
 }
@@ -53,8 +52,8 @@ static __inline__ double __fast_log (double x)
       "fyl2x"
        : "=t" (res) : "0" (x) : "st(1)");
 #elif defined(__aarch64__)
-  // TODO
-  res = 0.0;
+   // TODO: Complete AArch64 assembly implementation
+   res = log (x);
 #endif
    return res;
 }
@@ -69,8 +68,8 @@ static __inline__ long double __fast_logl (long double x)
      "fyl2x"
       : "=t" (res) : "0" (x) : "st(1)");
 #elif defined(__aarch64__)
-  // TODO
-  res = 0.0;
+  // TODO: Complete AArch64 assembly implementation
+  res = log (x);
 #endif
    return res;
 }
@@ -116,8 +115,8 @@ static __inline__ long double __fast_log1pl (long double x)
        "fyl2xp1"
        : "=t" (res) : "0" (x) : "st(1)");
 #elif defined(__aarch64__)
-    // TODO
-    res = 0.0;
+    // TODO: Complete AArch64 assembly implementation
+    res = log1p (x);
 #endif
    }
    return res;

--- a/winsup/cygwin/math/fmodl.c
+++ b/winsup/cygwin/math/fmodl.c
@@ -3,6 +3,10 @@
  * This file is part of the mingw-w64 runtime package.
  * No warranty is given; refer to the file DISCLAIMER.PD within this package.
  */
+#if defined(__aarch64__)
+#include <math.h>
+#endif
+
 long double fmodl (long double x, long double y);
 
 long double
@@ -19,8 +23,8 @@ fmodl (long double x, long double y)
        "fstp    %%st(1)"
        : "=t" (res) : "0" (x), "u" (y) : "ax", "st(1)");
 #elif defined(__aarch64__)
-  // TODO
-  res = 0.0;
+  // TODO: Complete AArch64 assembly implementation
+  res = fmod (x, y);
 #endif
   return res;
 }

--- a/winsup/cygwin/math/frexpl.S
+++ b/winsup/cygwin/math/frexpl.S
@@ -128,7 +128,13 @@ L24:
 	leave
 	ret
 #elif defined(__aarch64__)
-	// TODO
+	// TODO: Complete AArch64 assembly implementation
+	str     x30, [sp]
+	mov     x1, sp
+	bl      frexp
+	ldr     w0, [sp]
+	ldr     x30, [sp]
+	ret
 #else
 	.error "Not supported on your platform yet"
 #endif

--- a/winsup/cygwin/math/ilogbl.S
+++ b/winsup/cygwin/math/ilogbl.S
@@ -77,7 +77,11 @@ __MINGW_USYMBOL(ilogbl):
 	movl	$0x80000001, %eax	/* FP_ILOGB0  */
 	ret
 #elif defined(__aarch64__)
-	// TODO
+	// TODO: Complete AArch64 assembly implementation
+	stp q0, q1, [sp, -32]!
+	bl ilogb
+	ldp q0, q1, [sp], 32
+	ret
 #else
 	.error "Not supported on your platform yet"
 #endif

--- a/winsup/cygwin/math/internal_logl.S
+++ b/winsup/cygwin/math/internal_logl.S
@@ -64,7 +64,11 @@ __MINGW_USYMBOL(__logl_internal):
 	fyl2x			// log(x)
 	ret
 #elif defined(__aarch64__)
-	// TODO
+	// TODO: Complete AArch64 assembly implementation
+	stp q0, q1, [sp, -32]!
+	bl log
+	ldp q0, q1, [sp], 32
+	ret
 #else
 	.error "Not supported on your platform yet"
 #endif

--- a/winsup/cygwin/math/ldexpl.c
+++ b/winsup/cygwin/math/ldexpl.c
@@ -17,9 +17,9 @@ long double ldexpl(long double x, int expn)
 	    : "=t" (res)
 	    : "0" (x), "u" ((long double) expn));
 #elif defined(__aarch64__)
-  // TODO
-  res = 0.0L;
-#endif 
+  // TODO: Complete AArch64 assembly implementation
+  res = (x * powl (2, expn));
+#endif
 
   if (!isfinite (res) || res == 0.0L)
     errno = ERANGE;

--- a/winsup/cygwin/math/log10l.S
+++ b/winsup/cygwin/math/log10l.S
@@ -91,7 +91,11 @@ __MINGW_USYMBOL(log10l):
 	fstp	%st(1)
 	ret
 #elif defined(__aarch64__)
-	// TODO
+	// TODO: Complete AArch64 assembly implementation
+	stp q0, q1, [sp, -32]!
+	bl log10
+	ldp q0, q1, [sp], 32
+	ret
 #else
 	.error "Not supported on your platform yet"
 #endif

--- a/winsup/cygwin/math/log1pl.S
+++ b/winsup/cygwin/math/log1pl.S
@@ -102,7 +102,11 @@ __MINGW_USYMBOL(log1pl):
 	fstp	%st(1)
 	ret
 #elif defined(__aarch64__)
-	// TODO
+	// TODO: Complete AArch64 assembly implementation
+	stp q0, q1, [sp, -32]!
+	bl log1p
+	ldp q0, q1, [sp], 32
+	ret
 #else
 	.error "Not supported on your platform yet"
 #endif

--- a/winsup/cygwin/math/log2l.S
+++ b/winsup/cygwin/math/log2l.S
@@ -85,7 +85,11 @@ __MINGW_USYMBOL(log2l):
 	fstp	%st(1)
 	ret
 #elif (__aarch64__)
-	// TODO
+	// TODO: Complete AArch64 assembly implementation
+	stp q0, q1, [sp, -32]!
+	bl log2
+	ldp q0, q1, [sp], 32
+	ret
 #else
 	.error "Not supported on your platform yet"
 #endif

--- a/winsup/cygwin/math/logbl.c
+++ b/winsup/cygwin/math/logbl.c
@@ -21,7 +21,8 @@ logbl (long double x)
        "fxtract\n\t"
        "fstp	%%st" : "=t" (res) : "0" (x));
 #elif defined(__aarch64__)
-  res = 0.0;
+  // TODO: Complete AArch64 assembly implementation
+  res = logb (x);
 #endif
   return res;
 }

--- a/winsup/cygwin/math/pow.def.h
+++ b/winsup/cygwin/math/pow.def.h
@@ -102,7 +102,8 @@ internal_modf (__FLT_TYPE value, __FLT_TYPE *iptr)
     "fldcw 4(%%esp)\n"
     "addl $8, %%esp\n\tpop %%eax\n" : "=t" (int_part) : "0" (value)); /* round */
 #elif defined(__aarch64__)
-  // TODO
+  // TODO: Complete AArch64 assembly implementation
+  int_part = round (value);
 #endif
   if (iptr)
     *iptr = int_part;
@@ -209,8 +210,7 @@ __FLT_ABI(pow) (__FLT_TYPE x, __FLT_TYPE y)
 #if defined(__x86_64__) || defined(__i386__)
 	  asm volatile ("fsqrt" : "=t" (rslt) : "0" (x));
 #elif defined(__aarch64__)
-	  // TODO
-	  rslt = 0.0;
+	  asm volatile  ("fsqrt %d0, %d1" : "=w" (rslt) : "w" (x));
 #endif
 	  return rslt;
 	}

--- a/winsup/cygwin/math/remainder.S
+++ b/winsup/cygwin/math/remainder.S
@@ -38,7 +38,11 @@ __MINGW_USYMBOL(remainder):
 	fstp	%st(1)
 	ret
 #elif defined(__aarch64__)
-	// TODO
+	// TODO: Complete AArch64 assembly implementation
+	stp d0, d1, [sp, -16]!
+	bl remainder
+	ldp d0, d1, [sp], 16
+	ret
 #else
 	.error "Not supported on your platform yet"
 #endif

--- a/winsup/cygwin/math/remainderf.S
+++ b/winsup/cygwin/math/remainderf.S
@@ -38,7 +38,11 @@ __MINGW_USYMBOL(remainderf):
 	fstp	%st(1)
 	ret
 #elif defined(__aarch64__)
-	// TODO
+	// TODO: Complete AArch64 assembly implementation
+	stp s0, s1, [sp, -16]!
+	bl remainderf
+	ldp s0, s1, [sp], 16
+	ret
 #else
 	.error "Not supported on your platform yet"
 #endif

--- a/winsup/cygwin/math/remainderl.S
+++ b/winsup/cygwin/math/remainderl.S
@@ -37,7 +37,11 @@ __MINGW_USYMBOL(remainderl):
 	fstp	%st(1)
 	ret
 #elif defined(__aarch64__)
-	// TODO
+	// TODO: Complete AArch64 assembly implementation
+	stp q0, q1, [sp, -32]!
+	bl remainderl
+	ldp q0, q1, [sp], 32
+	ret
 #else
 	.error "Not supported on your platform yet"
 #endif

--- a/winsup/cygwin/math/remquol.S
+++ b/winsup/cygwin/math/remquol.S
@@ -73,7 +73,13 @@ __MINGW_USYMBOL(remquol):
 
         ret
 #elif defined(__aarch64__)
-	// TODO
+	// TODO: Complete AArch64 assembly implementation
+        stp     x0, x1, [sp, -16]!
+        stp     q0, q1, [sp, -32]!
+        bl      remquo
+        ldp     q0, q1, [sp], 32
+        ldp     x0, x1, [sp], 16
+        ret
 #else
 	.error "Not supported on your platform yet"
 #endif

--- a/winsup/cygwin/math/scalbl.S
+++ b/winsup/cygwin/math/scalbl.S
@@ -33,7 +33,18 @@ __MINGW_USYMBOL(scalbl):
 	fstp	%st(1)
 	ret
 #elif defined(__aarch64__)
-	// TODO
+    fcvtzs x1, d1        
+    fmov x0, d0          
+    ubfx x2, x0, #52, #11  
+    add x2, x2, x1      
+    cmp x2, #0          
+    csel x2, xzr, x2, lt
+    mov x3, #0x7FF      
+    cmp x2, x3          
+    csel x2, x2, x3, lt  
+    bfi x0, x2, #52, #11
+    fmov d0, x0          
+    ret
 #else
 	.error "Not supported on your platform yet"
 #endif

--- a/winsup/cygwin/math/scalbnl.S
+++ b/winsup/cygwin/math/scalbnl.S
@@ -35,7 +35,12 @@ __MINGW_USYMBOL(scalbnl):
 	fstp	%st(1)
 	ret
 #elif defined(__aarch64__)
-	// TODO
+	// TODO: Complete AArch64 assembly implementation
+	scvtf d1, w1
+	fmov d2, #2.0
+	bl pow
+	fmul d0, d0, d1
+	ret
 #else
 	.error "Not supported on your platform yet"
 #endif

--- a/winsup/cygwin/math/sinl_internal.S
+++ b/winsup/cygwin/math/sinl_internal.S
@@ -56,7 +56,11 @@ __MINGW_USYMBOL(__sinl_internal):
 	fsin
 	ret
 #elif defined(__aarch64__)
-	// TODO
+	// TODO: Complete AArch64 assembly implementation
+	stp q0, q1, [sp, -32]!
+	bl sin
+	ldp q0, q1, [sp], 32
+	ret
 #else
 	.error "Not supported on your platform yet"
 #endif

--- a/winsup/cygwin/math/sqrt.def.h
+++ b/winsup/cygwin/math/sqrt.def.h
@@ -90,7 +90,7 @@ __FLT_ABI (sqrt) (__FLT_TYPE x)
 #elif defined(_X86_) || defined(__i386__) || defined(_AMD64_) || defined(__x86_64__)
   asm volatile ("fsqrt" : "=t" (res) : "0" (x));
 #elif defined(__aarch64__)
-  // TODO
+  asm volatile ("fsqrt %d0, %d1" : "=w"(res) : "w"(x));
 #else
 #error Not supported on your platform yet
 #endif

--- a/winsup/cygwin/math/tanl.S
+++ b/winsup/cygwin/math/tanl.S
@@ -60,7 +60,11 @@ __MINGW_USYMBOL(tanl):
 	fstp	%st(0)
 	ret
 #elif defined(__aarch64__)
-	// TODO
+	// TODO: Complete AArch64 assembly implementation
+	stp q0, q1, [sp, -32]!
+	bl tan
+	ldp q0, q1, [sp], 32
+	ret
 #else
 	.error "Not supported on your platform yet"
 #endif


### PR DESCRIPTION
This PR introduces Math-Functions implementations for the aarch64 target, addressing [Cygwin: Port of mathematical functions](https://github.com/Windows-on-ARM-Experiments/mingw-woarm64-build/issues/251)

- Most functions are implemented in C to enable intial functionality, with a plan to transition them into arm64 assembly in a future update.
- For assembly files they are branched and linked to the fallback C implementations in the Newlib repository.
- Functions like square root utilize the existing opcode `sqrt` as they are already supported in aarch64 for efficient implementation.

Doc: [Math_funcs_test_programs.xlsx](https://github.com/user-attachments/files/19627526/Math_funcs_test_programs.xlsx)
