### PR TITLE
Workarounds needed to run `winsup` testsuite on the CI with WSL runner

### DIFF
--- a/winsup/testsuite/Makefile.am
+++ b/winsup/testsuite/Makefile.am
@@ -365,11 +365,13 @@ export cygrun=$(builddir)/mingw/cygrun
 # dependencies other than cygwin1.dll.
 #
 
+BUSYBOX := $(shell which busybox)
+
 check-local:
 	$(MKDIR_P) ${builddir}/testinst/tmp
-	cd ${builddir}/testinst/bin && cp /usr/libexec/busybox/bin/busybox.exe sh.exe
-	cd ${builddir}/testinst/bin && cp /usr/libexec/busybox/bin/busybox.exe sleep.exe
-	cd ${builddir}/testinst/bin && cp /usr/libexec/busybox/bin/busybox.exe ls.exe
+	cd ${builddir}/testinst/bin && cp $(BUSYBOX) sh.exe
+	cd ${builddir}/testinst/bin && cp $(BUSYBOX) sleep.exe
+	cd ${builddir}/testinst/bin && cp $(BUSYBOX) ls.exe
 
 # target to build all the programs needed by check, without running check
 check_programs: $(check_PROGRAMS)

--- a/winsup/testsuite/cygrun.sh
+++ b/winsup/testsuite/cygrun.sh
@@ -14,6 +14,5 @@ then
     $cygrun "$exe -v -cygwin $windows_runtime_root/cygwin1.dll"
 else
     # Removing cygdrop $cygrun to make the tests pass while testing on wsl-env
-    WSLENV="$WSLENV:PATH/p" \
     $exe
 fi

--- a/winsup/testsuite/cygrun.sh
+++ b/winsup/testsuite/cygrun.sh
@@ -14,5 +14,5 @@ then
     $cygrun "$exe -v -cygwin $windows_runtime_root/cygwin1.dll"
 else
     # Removing cygdrop $cygrun to make the tests pass while testing on wsl-env
-    $exe
+    timeout --preserve-status 300 "$exe"
 fi


### PR DESCRIPTION
Includes the following changes:

*   Revert of setting `WSLENV` inc `cygrun.sh` as this is better to be set by the build scripts.
*   Add `timeout` command with 60 seconds timeout to `cygrun.sh` to handle frozen tests.
*   Workaround for using WSL `busybox`.

Validated by https://github.com/Windows-on-ARM-Experiments/mingw-woarm64-build/actions/runs/15187488898