### PR TITLE
Allow to build `cygserver` conditionally

### DIFF
--- a/winsup/Makefile.am
+++ b/winsup/Makefile.am
@@ -14,10 +14,18 @@ cygdoc_DATA = \
 	CYGWIN_LICENSE \
 	COPYING
 
-SUBDIRS = cygwin cygserver testsuite
+SUBDIRS = cygwin testsuite
+
+if BUILD_CYGSERVER
+SUBDIRS += cygserver
+endif
 
 if BUILD_DOC
 SUBDIRS += doc
 endif
 
-cygserver testsuite: cygwin
+testsuite: cygwin
+
+if BUILD_CYGSERVER
+cygserver: cygwin
+endif

--- a/winsup/configure.ac
+++ b/winsup/configure.ac
@@ -81,6 +81,13 @@ AC_ARG_ENABLE(doc,
 	      enable_doc=yes)
 AM_CONDITIONAL(BUILD_DOC, [test $enable_doc != "no"])
 
+# Disabling build of cygserver is needed for zero-bootstrap build of stage 1
+# Cygwin toolchain where the linker is not able to produce executables yet.
+AC_ARG_ENABLE(cygserver,
+	      [AS_HELP_STRING([--disable-cygserver], [do not build cygserver])],,
+	      enable_cygserver=yes)
+AM_CONDITIONAL(BUILD_CYGSERVER, [test $enable_cygserver != "no"])
+
 AC_CHECK_PROGS([DOCBOOK2XTEXI], [docbook2x-texi db2x_docbook2texi])
 if test -z "$DOCBOOK2XTEXI" ; then
     if test "x$enable_doc" != "xno"; then

--- a/winsup/cygserver/Makefile.am
+++ b/winsup/cygserver/Makefile.am
@@ -12,6 +12,9 @@ cygserver_flags=$(cxxflags_common) -Wimplicit-fallthrough=5 -Werror -DSYSCONFDIR
 AM_CXXFLAGS = $(CFLAGS)
 
 noinst_LIBRARIES = libcygserver.a
+if BUILD_CYGSERVER
+sbin_PROGRAMS = cygserver
+endif
 bin_SCRIPTS = cygserver-config
 
 cygserver_SOURCES = \


### PR DESCRIPTION
Cygserver cannot be built during stage 1 in cross-compilation scenario while it can for stage 2. This PR makes possible to skip build of `cygserver` during stage 1 using `--disable-cygserver` configure option this allows to revert the previous workaround.

Validated by https://github.com/Windows-on-ARM-Experiments/mingw-woarm64-build/actions/runs/15188424029