### PR TITLE
Increase jump buffer length to 24 to fit all non-volatile registers

### DIFF
--- a/newlib/libc/include/machine/setjmp.h
+++ b/newlib/libc/include/machine/setjmp.h
@@ -22,7 +22,15 @@ _BEGIN_STD_C
 #endif
 
 #if defined(__aarch64__)
-#define _JBLEN 22
+# if defined(__CYGWIN__)
+/* 
+ * Windows Arm64 ABI requires saving x19-x28, FP, LR, SP, FPCR, FPSR, d8-d15
+ * and jump address to jmp_buf.
+ */
+#  define _JBLEN 24
+# else
+#  define _JBLEN 22
+# endif
 #define _JBTYPE long long
 #endif
 


### PR DESCRIPTION
The `jmp_buf` size needs to be increased to 24 to fit all non-volatile registers: `x19`-`x28` + `FP` + `LR` + `SP` + `FPCR` + `FPSR` + `d8`-`d15` + jump adddres = 24.

This was validated with `msvcrt` implementation on the following sample:
```c
#include <setjmp.h>
#include <stdio.h>

static jmp_buf env;

void
second_stage (void)
{
  printf ("In second_stage(), jumping back to main...\n");
  longjmp (env, 42);
}

void
first_stage (void)
{
  printf ("In first_stage(), calling second_stage()\n");
  second_stage ();
  // This line will not be executed because longjmp will jump back to main.
  printf ("Returned to first_stage()\n");
}

int
main (void)
{
  printf ("jmp_buf size: %zu bytes\n", sizeof (jmp_buf));
  
  int val = setjmp (env);
  if (val == 0)
    {
      // Initial invocation
      printf ("setjmp returned %d (initial)\n", val);
      first_stage ();
    }
  else
    {
      // After longjmp
      printf ("setjmp returned %d (after longjmp)\n", val);
    }
  return 0;
}
```
The `sizeof(jmp_buf)` is 24 * 8 bytes.

Validated by https://github.com/Windows-on-ARM-Experiments/mingw-woarm64-build/actions/runs/15323317368