### PR TITLE
Implement `stabilize_sig_stack`

### DIFF
--- a/winsup/cygwin/Makefile.am
+++ b/winsup/cygwin/Makefile.am
@@ -25,6 +25,10 @@ if TARGET_X86_64
 AM_CCASFLAGS=-D_WIN64
 endif
 
+if TARGET_AARCH64
+AM_CCASFLAGS=-Wa,-march=armv8.1-a
+endif
+
 target_builddir=@target_builddir@
 newlib_build=$(target_builddir)/newlib
 

--- a/winsup/cygwin/scripts/gendef
+++ b/winsup/cygwin/scripts/gendef
@@ -679,7 +679,63 @@ siglongjmp:
 	.globl  longjmp
 	.seh_proc longjmp
 longjmp:
+	// prologue
+	stp	fp, lr, [sp, #-0x20]!		// save FP and LR registers, allocate additional 16 bytes for function arguments
+	stp	x0, x1, [sp, #0x10]		// save function arguments (jump buffer and return value)
+	mov	fp, sp				// establishing frame chain
 	.seh_endprologue
+1:
+	bl	stabilize_sig_stack		// call stabilize_sig_stack which returns TLS pointer in x0
+	ldr	x2, [sp, #0x10]			// get jump buffer pointer from stack
+	ldr	x10, [x2]			// get old signal stack from jump buffer
+
+	// restore stack pointer in TLS
+	ldr	x11, =_cygtls.stackptr
+	add	x11, x0, x11
+	str	x10, [x11]
+
+	// release lock by decrementing counter
+	ldr	x11, =_cygtls.stacklock
+	add	x11, x0, x11
+	ldr	w12, [x11]
+	sub	w12, w12, #1
+	str	w12, [x11]
+
+	// we're not in cygwin anymore, clear "in cygwin" flag
+	ldr	x11, =_cygtls.incyg
+	add	x11, x0, x11
+	mov	w12, #0
+	str	w12, [x11]
+
+	// get saved return value before SP is restored
+	ldr	x0, [sp, #0x10]
+
+	// restore callee-saved registers from jump buffer
+	ldp	x19, x20, [x2, #0x08]		// restore x19, x20
+	ldp	x21, x22, [x2, #0x18]		// restore x21, x22
+	ldp	x23, x24, [x2, #0x28]		// restore x23, x24
+	ldp	x25, x26, [x2, #0x38]		// restore x25, x26
+	ldp	x27, x28, [x2, #0x48]		// restore x27, x28
+	ldp	fp, lr, [x2, #0x58]		// restore x29 (frame pointer) and x30 (link register)
+	ldr	x10, [x2, #0x68]		// get saved stack pointer
+	mov	sp, x10				// restore stack pointer
+	ldr	x10, [x2, #0x70]		// load floating-point control register
+	msr	fpcr, x10			// restore FPCR
+	ldr	x10, [x2, #0x78]		// load floating-point status register
+	msr	fpsr, x10			// restore FPSR
+
+	// restore floating-point registers (d8-d15)
+	ldp	d8, d9, [x2, #0x80]
+	ldp	d10, d11, [x2, #0x90]
+	ldp	d12, d13, [x2, #0xA0]
+	ldp	d14, d15, [x2, #0xB0]
+
+	// ensure return value is non-zero (C standard requirement)
+	cbnz	x0, 0f
+	mov	x0, #1
+0:
+	// epilogue
+	add	sp, sp, #0x10			// FP and LR are already restored, just restore SP as it would be popped
 	ret
 	.seh_endproc
 EOF

--- a/winsup/cygwin/scripts/gendef
+++ b/winsup/cygwin/scripts/gendef
@@ -401,71 +401,45 @@ _sigdelayed_end:
 stabilize_sig_stack:
 	// prologue
 	stp	fp, lr, [sp, #-0x10]!		// save FP and LR registers
-	.seh_save_fplr_x+ 16
+	.seh_save_fplr_x 16
+	stp	x19, x20, [sp, #-0x10]!
+	.seh_save_regp_x x19, 16
 	.seh_endprologue
 
-	ldr	x10, [x18, #0x8]		// keep thread local storage base address in x10
+	ldr	x9, [x18, #0x8]		// load thread local storage base address
+	mov	x19, #_cygtls.current_sig	// load the _cygtls.current_sig offset
+	add x19, x9, x19	// final address of current_sig
+	mov	x20, #_cygtls.incyg	// load the _cygtls.incyg offset
+	add x20, x9, x20	// final address of incyg
 
-	// try to acquire the lock
-	mov	w9, #1				// set up value for atomic exchange
-	ldr	x11, =_cygtls.stacklock		// load the symbol address/offset
-	add	x12, x10, x11			// calculate final address
 1:
-	ldaxr	w13, [x12]			// load with acquire semantics
-	stlxr	w14, w9, [x12]			// store with release semantics
-	cbnz	w14, 1b				// if store failed, retry
-	cbz	w13, 2f				// if lock was acquired, continue
-	yield					// yield to allow other threads to run
-	b	1b				// retry acquiring the lock
-2:
-	// lock acquired, increment incyg counter
-	ldr	x11, =_cygtls.incyg		// load the symbol address/offset
-	add	x12, x10, x11			// calculate final address
-	ldr	w9, [x12]			// load current value of incyg counter
-	add	w9, w9, #1			// increment incyg counter
-	str	w9, [x12]			// store incremented value back
-
 	// check if there is a current signal to handle 
-	ldr	x11, =_cygtls.current_sig	// load the symbol address/offset
-	ldr	w9, [x10, x11]			// load current value of current_sig
-	cbz	w9, 3f				// if no current signal, jump to cleanup
+	ldr	w9, [x19]			// load current_sig
+	cbz	w9, 2f				// if no current signal, jump to cleanup
 
-	// release lock before calling signal handler
-	ldr	x11, =_cygtls.stacklock		// load the symbol address/offset
-	add	x12, x10, x11			// calculate final address
-	ldr	w9, [x12]			// load current value of stacklock counter
-	sub	w9, w9, #1			// decrement stacklock counter
-	stlr	w9, [x12]			// store with release semantics
+	mov w9, #1				// specify increment
+	staddl w9, [x20]		// atomically increment incyg with a lock
 
 	// prepare arguments and call signal handler
-	ldr	x0, =_cygtls.start_offset	// load the symbol address/offset
-	add	x0, x10, x0			// calculate final address
+	mov	x0, #_cygtls.start_offset	// load the _cygtls.start_offset offset
+	add	x0, x10, x0			// final address of start_offset
 	bl	_ZN7_cygtls19call_signal_handlerEv
-	ldr	x10, [x18, #0x8]		// restore x10 that may have been modified by the call
 
 	// decrement incyg counter
-	ldr	x11, =_cygtls.incyg		// load the symbol address/offset
-	add	x12, x10, x11			// calculate final address
-	ldr	w9, [x12]			// load current value of incyg counter
-	sub	w9, w9, #1			// decrement incyg counter
-	str	w9, [x12]			// store decremented value back
+	mov w9, #-1				// specify decrement
+	staddl w9, [x20]		// atomically decrement incyg with a lock
 
 	// go to the beginning to handle another signal
 	b	1b
-3:
-	// no signal to handle, decrement incyg counter
-	ldr	x11, =_cygtls.incyg		// load the symbol address/offset
-	add	x12, x10, x11			// calculate final address
-	ldr	w9, [x12]			// load current value of incyg counter
-	sub	w9, w9, #1			// decrement incyg counter
-	str	w9, [x12]			// store decremented value back
-
-	mov	x0, x10				// return TLS address in x0 (return value)
+2:
+	ldr	x0, [x18, #0x8]		// return TLS address in x0 (return value)
 
 	// epilogue
 	.seh_startepilogue
+	ldp	x19, x20, [sp], #0x10
+	.seh_save_regp_x x19, 16
 	ldp	fp, lr, [sp], #0x10
-	.seh_save_fplr_x+ 16
+	.seh_save_fplr_x 16
 	.seh_endepilogue
 	ret
 	.seh_endproc
@@ -655,13 +629,6 @@ setjmp:
 	ldr	x3, [x2]
 	// TODO: Save the value somewhere.
 
-	// decrement the stack lock
-	ldr	x2, =_cygtls.stacklock
-	add	x2, x0, x2
-	ldr	w3, [x2]
-	sub	w3, w3, #1
-	str	w3, [x2]
-
 	mov	w0, #0				// return 0
 
 	// epilogue
@@ -693,13 +660,6 @@ longjmp:
 	ldr	x11, =_cygtls.stackptr
 	add	x11, x0, x11
 	str	x10, [x11]
-
-	// release lock by decrementing counter
-	ldr	x11, =_cygtls.stacklock
-	add	x11, x0, x11
-	ldr	w12, [x11]
-	sub	w12, w12, #1
-	str	w12, [x11]
 
 	// we're not in cygwin anymore, clear "in cygwin" flag
 	ldr	x11, =_cygtls.incyg

--- a/winsup/cygwin/scripts/gendef
+++ b/winsup/cygwin/scripts/gendef
@@ -399,7 +399,74 @@ _sigdelayed_end:
 
 	.seh_proc stabilize_sig_stack
 stabilize_sig_stack:
+	// prologue
+	stp	fp, lr, [sp, #-0x10]!		// save FP and LR registers
+	.seh_save_fplr_x+ 16
 	.seh_endprologue
+
+	ldr	x10, [x18, #0x8]		// keep thread local storage base address in x10
+
+	// try to acquire the lock
+	mov	w9, #1				// set up value for atomic exchange
+	ldr	x11, =_cygtls.stacklock		// load the symbol address/offset
+	add	x12, x10, x11			// calculate final address
+1:
+	ldaxr	w13, [x12]			// load with acquire semantics
+	stlxr	w14, w9, [x12]			// store with release semantics
+	cbnz	w14, 1b				// if store failed, retry
+	cbz	w13, 2f				// if lock was acquired, continue
+	yield					// yield to allow other threads to run
+	b	1b				// retry acquiring the lock
+2:
+	// lock acquired, increment incyg counter
+	ldr	x11, =_cygtls.incyg		// load the symbol address/offset
+	add	x12, x10, x11			// calculate final address
+	ldr	w9, [x12]			// load current value of incyg counter
+	add	w9, w9, #1			// increment incyg counter
+	str	w9, [x12]			// store incremented value back
+
+	// check if there is a current signal to handle 
+	ldr	x11, =_cygtls.current_sig	// load the symbol address/offset
+	ldr	w9, [x10, x11]			// load current value of current_sig
+	cbz	w9, 3f				// if no current signal, jump to cleanup
+
+	// release lock before calling signal handler
+	ldr	x11, =_cygtls.stacklock		// load the symbol address/offset
+	add	x12, x10, x11			// calculate final address
+	ldr	w9, [x12]			// load current value of stacklock counter
+	sub	w9, w9, #1			// decrement stacklock counter
+	stlr	w9, [x12]			// store with release semantics
+
+	// prepare arguments and call signal handler
+	ldr	x0, =_cygtls.start_offset	// load the symbol address/offset
+	add	x0, x10, x0			// calculate final address
+	bl	_ZN7_cygtls19call_signal_handlerEv
+	ldr	x10, [x18, #0x8]		// restore x10 that may have been modified by the call
+
+	// decrement incyg counter
+	ldr	x11, =_cygtls.incyg		// load the symbol address/offset
+	add	x12, x10, x11			// calculate final address
+	ldr	w9, [x12]			// load current value of incyg counter
+	sub	w9, w9, #1			// decrement incyg counter
+	str	w9, [x12]			// store decremented value back
+
+	// go to the beginning to handle another signal
+	b	1b
+3:
+	// no signal to handle, decrement incyg counter
+	ldr	x11, =_cygtls.incyg		// load the symbol address/offset
+	add	x12, x10, x11			// calculate final address
+	ldr	w9, [x12]			// load current value of incyg counter
+	sub	w9, w9, #1			// decrement incyg counter
+	str	w9, [x12]			// store decremented value back
+
+	mov	x0, x10				// return TLS address in x0 (return value)
+
+	// epilogue
+	.seh_startepilogue
+	ldp	fp, lr, [sp], #0x10
+	.seh_save_fplr_x+ 16
+	.seh_endepilogue
 	ret
 	.seh_endproc
 EOF

--- a/winsup/cygwin/scripts/gendef
+++ b/winsup/cygwin/scripts/gendef
@@ -622,8 +622,50 @@ sigsetjmp:
 	.globl  setjmp
 	.seh_proc setjmp
 setjmp:
+	// prologue
+	stp	fp, lr, [sp, #-0x10]!		// save FP and LR registers
 	.seh_endprologue
-	mov x0, 0
+
+	// save callee-saved registers from jump buffer
+	stp	x19, x20, [x0, #0x08]		// save x19 and x20
+	stp	x21, x22, [x0, #0x18]		// save x21 and x22
+	stp	x23, x24, [x0, #0x28]		// save x23 and x24
+	stp	x25, x26, [x0, #0x38]		// save x25 and x26
+	stp	x27, x28, [x0, #0x48]		// save x27 and x28
+	stp	fp, lr, [x0, #0x58]		// save x29 (frame pointer) and x30 (link register)
+	mov	x1, sp				// get the current stack pointer
+	str	x1, [x0, #0x68]			// save SP
+	mrs	x1, fpcr			// get floating-point control register
+	str	x1, [x0, #0x70]			// save FPCR
+	mrs	x1, fpsr			// get floating-point status register
+	str	x1, [x0, #0x78]			// save FPSR
+
+
+	// save floating-point registers (d8-d15)
+	stp	d8, d9, [x0, #0x80]
+	stp	d10, d11, [x0, #0x90]
+	stp	d12, d13, [x0, #0xA0]
+	stp	d14, d15, [x0, #0xB0]
+
+	bl	stabilize_sig_stack		// call stabilize_sig_stack (returns TLS in x0)
+
+	// store the stack pointer to ...
+	ldr	x2, =_cygtls.stackptr
+	add	x2, x0, x2
+	ldr	x3, [x2]
+	// TODO: Save the value somewhere.
+
+	// decrement the stack lock
+	ldr	x2, =_cygtls.stacklock
+	add	x2, x0, x2
+	ldr	w3, [x2]
+	sub	w3, w3, #1
+	str	w3, [x2]
+
+	mov	w0, #0				// return 0
+
+	// epilogue
+	ldp	fp, lr, [sp], #0x10		// restore saved FP and LR registers
 	ret
 	.seh_endproc
 


### PR DESCRIPTION
Implements `stabilize_sig_stack`  routine for AArch64 that is used both in `setjmp` and `longjmp` routines implementation. Please, refer to x64 implementation for comparison.

Validated by https://github.com/Windows-on-ARM-Experiments/mingw-woarm64-build/actions/runs/15304776330