### PR TITLE
Add inline assembly pthread wrapper for aarch64

### DIFF
--- a/winsup/cygwin/create_posix_thread.cc
+++ b/winsup/cygwin/create_posix_thread.cc
@@ -100,7 +100,22 @@ pthread_wrapper (PVOID arg)
 	   : : [WRAPPER_ARG] "o" (wrapper_arg),
 	       [CYGTLS] "i" (__CYGTLS_PADSIZE__));
 #elif defined(__aarch64__)
-  // TODO
+  /* Sets up a new thread stack, frees the original OS stack,
+   * and calls the thread function with its arg using AArch64 ABI. */
+  __asm__ __volatile__ ("\n\
+	   mov     x19, %[WRAPPER_ARG]           // x19 = &wrapper_arg            \n\
+	   ldr     x10, [x19, #24]               // x10 = wrapper_arg.stackbase   \n\
+	   sub     sp, x10, %[CYGTLS]            // sp = stackbase - (CYGTLS + 32)\n\
+	   mov     fp, xzr                       // clear frame pointer (x29)     \n\
+	   mov     x0, sp                        // x0 = new stack pointer        \n\
+	   mov     x1, xzr                       // x1 = 0 (dwSize)               \n\
+	   mov     x2, #0x8000                   // x2 = MEM_RELEASE              \n\
+	   bl      VirtualFree                   // free original stack           \n\
+	   ldp     x19, x0, [x19]                // x19 = func, x0 = arg          \n\
+	   blr     x19                           // call thread function          \n"
+	   : : [WRAPPER_ARG] "r" (&wrapper_arg),
+	       [CYGTLS] "r" (__CYGTLS_PADSIZE__ + 32) // add 32 bytes shadow space
+	   : "x0", "x1", "x2", "x10", "x19", "x29", "memory");
 #else
 #error unimplemented for this target
 #endif


### PR DESCRIPTION
This change introduces AArch64-specific inline assembly implementation that prepares the environment for starting a new thread. It performs the following actions:

- Loads the func pointer, arg, and stackbase from `wrapper_arg`
- Adjusts stack pointer with __CYGTLS_PADSIZE__ to ensure TLS alignment
- Reserves 32 bytes of shadow space & clears the frame pointer(x29)
- Moves the arg into x0 and calls the thread function via x12