### PR TITLE
Fix upstream workflow build

### DIFF
--- a/winsup/configure.ac
+++ b/winsup/configure.ac
@@ -136,6 +136,9 @@ AC_CONFIG_FILES([
     Makefile
     cygwin/Makefile
     cygserver/Makefile
+    doc/Makefile
+    utils/Makefile
+    utils/mingw/Makefile
     testsuite/Makefile
     testsuite/mingw/Makefile
 ])

--- a/winsup/testsuite/cygrun.sh
+++ b/winsup/testsuite/cygrun.sh
@@ -13,6 +13,10 @@ then
     windows_runtime_root=$(cygpath -m $runtime_root)
     $cygrun "$exe -v -cygwin $windows_runtime_root/cygwin1.dll"
 else
-    # Removing cygdrop $cygrun to make the tests pass while testing on wsl-env
-    timeout --preserve-status 300 "$exe"
+    if uname | grep -qi cygwin; then
+        cygdrop $cygrun $exe
+    else
+        # Running under WSL.
+        timeout --preserve-status 300 "$exe"
+    fi
 fi


### PR DESCRIPTION
This PR reverts and generifies the previous workarounds added to allow Cygwin toolchain build with upstream MinGW headers. This is needed to fix the build on the upstream workflow as it is using different version of Win32 headers. It also requires a corresponding [change](https://github.com/Windows-on-ARM-Experiments/mingw-woarm64-build/pull/322) to our workflow.

Tested by https://github.com/Windows-on-ARM-Experiments/mingw-woarm64-build/actions/runs/15416788818