### PR TITLE
Build and test AArch64 Cygwin using Cygwin cross-toolchain on Windows Arm64 runner

### DIFF
--- a/.github/workflows/cygwin.yml
+++ b/.github/workflows/cygwin.yml
@@ -117,6 +117,7 @@ jobs:
       # prepare non-ephemeral runner environment
       - name: Prepare environment
         run: |
+          Get-ChildItem -Force
           if (Test-Path -Path newlib-cygwin) {
             Remove-Item -Recurse -Force newlib-cygwin
           }
@@ -197,7 +198,7 @@ jobs:
           export MAKEFLAGS="V=1 -j$(nproc)"
           export CYGWIN=winsymlinks:sys
 
-          mkdir build install
+          mkdir -p build install
           (cd newlib-cygwin/winsup && ./autogen.sh)
           (cd build && ../newlib-cygwin/configure --target=${{ matrix.arch }}-pc-cygwin --prefix=$(realpath $(pwd)/../install) )
           make -C build
@@ -233,33 +234,53 @@ jobs:
           path: build.tar.bz2
 
   windows-build:
-    runs-on: windows-latest
+    runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
       matrix:
         include:
-        - target: x86_64-pc-cygwin
+        - build: x86_64-pc-cygwin
+          target: x86_64-pc-cygwin
+          buildarch: x86_64
           pkgarch: x86_64
+          runner: windows-latest
+        - build: x86_64-pc-cygwin
+          target: aarch64-pc-cygwin
+          buildarch: x86_64
+          pkgarch: aarch64
+          runner: windows-11-arm
     name: Windows native ${{ matrix.pkgarch }}
+
+    defaults:
+      run:
+        shell: bash --noprofile --norc -eo pipefail -c "$(s=$(/usr/bin/cygpath '{0}') && /usr/bin/sed -i 's/\r$//' $s && echo $s)"
+    env:
+      GH_TOKEN: ${{ github.token }}
 
     steps:
     # checkout action uses the native git (we can avoid this messing up line
     # endings, but this could still be dangerous e.g if we need symlinks in the
     # repo)
-    - run: git config --global core.autocrlf input
+    - name: Configure git
+      run: |
+        git config --global core.autocrlf input
+      shell: powershell
+
     # remove inheritable permissions since they break assumptions testsuite
     # makes about file modes
-    - name: adjust permissions
+    - name: Adjust permissions
       run: |
         icacls . /inheritance:r
         icacls . /grant Administrators:F
+      shell: powershell
+
     - uses: actions/checkout@v3
 
     # install cygwin and build tools
     - name: Install Cygwin
       uses: cygwin/cygwin-install-action@master
       with:
-        platform: ${{ matrix.pkgarch }}
+        platform: ${{ matrix.buildarch }}
         packages: >-
           autoconf,
           automake,
@@ -277,8 +298,8 @@ jobs:
           libiconv-devel,
           libzstd-devel,
           make,
-          mingw64-${{ matrix.pkgarch }}-gcc-g++,
-          mingw64-${{ matrix.pkgarch }}-zlib,
+          mingw64-${{ matrix.buildarch }}-gcc-g++,
+          mingw64-${{ matrix.buildarch }}-zlib,
           patch,
           perl,
           python39-lxml,
@@ -289,22 +310,47 @@ jobs:
           xmlto,
           zlib-devel
 
+    # download toolchain
+    - name: Download toolchain
+      if: ${{ matrix.pkgarch == 'aarch64' }}
+      run: |
+        export PATH=/usr/bin:$(cygpath ${SYSTEMROOT})/system32:$PATH
+        DIGEST=$(gh api repos/${{ github.repository }}/releases/latest \
+           --jq '.assets[] | select(.name | test("${{ matrix.target }}-toolchain.tar.xz")).digest')
+        gh release download \
+          --repo ${{ github.repository }} \
+          --pattern ${{ matrix.target }}-toolchain.tar.xz
+        sha256sum -c <<< "${DIGEST#sha256:} ${{ matrix.target }}-toolchain.tar.xz"
+
+    # install toolchain
+    - name: Install toolchain
+      if: ${{ matrix.pkgarch == 'aarch64' }}
+      run: |
+        mkdir -p toolchain/${{ matrix.target }}
+        tar -xzf ${{ matrix.target }}-toolchain.tar.xz -C toolchain/${{ matrix.target }}
+
     # build
     - name: Build Cygwin
-      run: >-
-        export PATH=/usr/bin:$(cygpath ${SYSTEMROOT})/system32 &&
-        export DESTDIR=$(realpath $(pwd)/install) &&
-        mkdir build install &&
-        (cd winsup; ./autogen.sh) &&
-        cd build &&
-        ../configure --prefix=/usr -v &&
-        export MAKEFLAGS=-j$(nproc) &&
-        make &&
-        export CYGWIN=winsymlinks:sys &&
-        make install -j1 tooldir=/usr gcc_tooldir=/usr DESTDIR=${DESTDIR} &&
-        (cd */newlib; make info man) &&
+      run: |
+        if [[ "${{ matrix.pkgarch }}" == "aarch64" ]]; then
+          export PATH=$(pwd)/toolchain/${{ matrix.target }}/bin:/usr/bin:$(cygpath ${SYSTEMROOT})/system32
+          export CXXFLAGS_FOR_TARGET="-D_WIN64 -I$(pwd)/toolchain/${{ matrix.target }}/include"
+          export LDFLAGS_FOR_TARGET="-L$(pwd)/toolchain/${{ matrix.target }}/lib"
+        else
+          export PATH=/usr/bin:$(cygpath ${SYSTEMROOT})/system32
+        fi
+        echo PATH=$PATH
+        export DESTDIR=$(realpath $(pwd)/install)
+        mkdir build install
+        (cd winsup; ./autogen.sh)
+        cd build
+        ../configure --prefix=/usr --build=${{ matrix.build }} --target=${{ matrix.target }} -v
+        export MAKEFLAGS=-j$(nproc)
+        make
+        export CYGWIN=winsymlinks:sys
+        make install -j1 tooldir=/usr gcc_tooldir=/usr DESTDIR=${DESTDIR}
+        (cd */newlib; make info man)
         (cd */newlib; make install-info install-man tooldir=/usr gcc_tooldir=/usr DESTDIR=${DESTDIR})
-      shell: bash --noprofile --norc -eo pipefail '{0}'
 
     # adjust install so it matches the physical arrangement of directories when
     # unpacked by setup
@@ -312,7 +358,6 @@ jobs:
       run: |
         mv -v install/usr/bin install/bin
         mv -v install/usr/lib install/lib
-      shell: bash --noprofile --norc -o igncr -eo pipefail '{0}'
 
     # upload installed cygwin as an artifact, for subsequent use in
     # test job(s)
@@ -325,23 +370,51 @@ jobs:
 
     # test
     - name: Test Cygwin
-      run: >-
-        export PATH=/usr/bin:$(cygpath ${SYSTEMROOT})/system32 &&
-        export MAKEFLAGS=-j$(nproc) &&
-        cd build &&
-        (export PATH=${{ matrix.target }}/winsup/testsuite/testinst/bin:${PATH} && cmd /c $(cygpath -wa ${{ matrix.target }}/winsup/cygserver/cygserver) &) &&
+      run: |
+        if [[ "${{ matrix.pkgarch }}" == "aarch64" ]]; then
+          export PATH=$(pwd)/toolchain/${{ matrix.target }}/bin:/usr/bin:$(cygpath ${SYSTEMROOT})/system32
+        else
+          export PATH=/usr/bin:$(cygpath ${SYSTEMROOT})/system32
+        fi
+        export MAKEFLAGS=-j$(nproc)
+        cd build
+        (export PATH=${{ matrix.target }}/winsup/testsuite/testinst/bin:${PATH} && cmd /c $(cygpath -wa ${{ matrix.target }}/winsup/cygserver/cygserver) &)
         (cd ${{ matrix.target }}/winsup; make check AM_COLOR_TESTS=always)
-      shell: bash --noprofile --norc -eo pipefail '{0}'
+      continue-on-error: ${{ matrix.pkgarch == 'aarch64' }}
+
+    # kill hanging processes
+    - name: Kill hanging processes
+      if: ${{ matrix.pkgarch == 'aarch64' && always() }}
+      run: |
+        taskkill /F /FI 'MODULES eq cygwin1.dll'
+        if (Test-Path -Path ${{ github.workspace }}\build\${{ matrix.target }}\winsup\testsuite\testinst\tmp) {
+          Remove-Item -Recurse -Force ${{ github.workspace }}\build\${{ matrix.target }}\winsup\testsuite\testinst\tmp
+        }
+        exit 0
+      shell: powershell
 
     # upload test logs to facilitate investigation of problems
     - name: Upload test logs
       uses: actions/upload-artifact@v4
       with:
-        name: testlogs
+        name: testlogs-${{ matrix.pkgarch }}
         path: |
           build/${{ matrix.target }}/winsup/testsuite/**/*.log
           build/${{ matrix.target }}/winsup/testsuite/**/*.trs
       if: ${{ !cancelled() }}
+
+    - name: Pack build folder
+      if: failure()
+      run: |
+        tar -cjf cygwin-${{ matrix.target }}-build.tar.bz2 build/
+
+    - name: Upload build folder
+      if: failure()
+      uses: actions/upload-artifact@v4
+      with:
+        name: cygwin-${{ matrix.target }}-build
+        retention-days: 1
+        path: cygwin-${{ matrix.target }}-build.tar.bz2
 
     # workaround problems with actions/checkout post-run step using cygwin git
     - name: Avoid actions/checkout post-run step using Cygwin git


### PR DESCRIPTION
Adds AArch64 Cygwin build variant to `windows-build` job. The package is built with x64 -> AArch64 cross-compiler but tested natively.