### PR TITLE
Add runtime relocation in dynamic linking and revert workarounds

### DIFF
--- a/winsup/cygwin/pseudo-reloc.cc
+++ b/winsup/cygwin/pseudo-reloc.cc
@@ -199,6 +199,9 @@ do_pseudo_reloc (void * start, void * end, void * base)
   ptrdiff_t reloc_target = (ptrdiff_t) ((char *)end - (char*)start);
   runtime_pseudo_reloc_v2 *v2_hdr = (runtime_pseudo_reloc_v2 *) start;
   runtime_pseudo_reloc_item_v2 *r;
+#ifdef __aarch64__
+  uint32_t opcode;
+#endif
 
   /* A valid relocation list will contain at least one entry, and
    * one v1 data structure (the smallest one) requires two DWORDs.
@@ -307,6 +310,13 @@ do_pseudo_reloc (void * start, void * end, void * base)
 	  if ((reldata & 0x8000) != 0)
 	    reldata |= ~((ptrdiff_t) 0xffff);
 	  break;
+#ifdef __aarch64__
+	case 12:
+	case 21:
+	  opcode = (*((unsigned int *)reloc_target));
+	  reldata = 0;
+	  break;
+#endif
 	case 32:
 	  reldata = (ptrdiff_t) (*((unsigned int *)reloc_target));
 #if defined (__x86_64__) || defined (_WIN64)
@@ -339,6 +349,31 @@ do_pseudo_reloc (void * start, void * end, void * base)
 	case 16:
 	  __write_memory ((void *) reloc_target, &reldata, 2);
 	  break;
+#ifdef __aarch64__
+	case 12:
+	  /* Replace add Xn, Xn, :lo12:label with ldr Xn, [Xn, :lo12:__imp__func].
+	     That loads the address of _func into Xn.  */
+	  opcode = 0xf9400000 | (opcode & 0x3ff); // ldr
+	  reldata = ((ptrdiff_t) base + r->sym) & ((1 << 12) - 1);
+	  reldata >>= 3;
+	  opcode |= reldata << 10;
+	  __write_memory ((void *) reloc_target, &opcode, 4);
+	  break;
+	case 21:
+	  /* Replace adrp Xn, label with adrp Xn, __imp__func.  */
+	  opcode &= 0x9f00001f;
+	  reldata = (((ptrdiff_t) base + r->sym) >> 12)
+		    - (((ptrdiff_t) base + r->target) >> 12);
+	  reldata &= (1 << 21) - 1;
+	  opcode |= (reldata & 3) << 29;
+	  reldata >>= 2;
+	  opcode |= reldata << 5;
+	  __write_memory ((void *) reloc_target, &opcode, 4);
+	  break;
+	/* A note regarding 26 bits relocation.
+	   A single opcode is not sufficient for 26 bits relocation in dynamic linking.
+	   The linker generates a jump stub instead.  */
+#endif
 	case 32:
 #if defined (__CYGWIN__) && defined (__x86_64__)
 	  if (reldata > (ptrdiff_t) __INT32_MAX__

--- a/winsup/testsuite/winsup.api/ltp/execle01.c
+++ b/winsup/testsuite/winsup.api/ltp/execle01.c
@@ -133,10 +133,6 @@ int exp_enos[]={0, 0};		/* Zero terminated list of expected errnos */
 
 int pid;		/* process id from fork */
 int status;		/* status returned from waitpid */
-
-#if defined(__aarch64__)
-__attribute__((dllimport))	/* workaround for large relocation issue in binutils */
-#endif
 extern char **environ;	/* pointer to this processes env, to pass along */
 
 int

--- a/winsup/testsuite/winsup.api/ltp/execve01.c
+++ b/winsup/testsuite/winsup.api/ltp/execve01.c
@@ -134,10 +134,6 @@ int exp_enos[]={0, 0};		/* Zero terminated list of expected errnos */
 int pid;			/* process id from fork */
 int status;			/* status returned from waitpid */
 char *const args[2]={"/usr/bin/test", 0};	/* argument list for execve call */
-
-#if defined(__aarch64__)
-__attribute__((dllimport))	/* workaround for large relocation issue in binutils */
-#endif
 extern char **environ;		/* pointer to this processes env, to pass along */
 
 int

--- a/winsup/testsuite/winsup.api/posix_spawn/chdir.c
+++ b/winsup/testsuite/winsup.api/posix_spawn/chdir.c
@@ -7,12 +7,6 @@
 #include <string.h>
 #include <unistd.h>
 
-/* Workaround for large relocation issue in binutils. */
-#if defined(__aarch64__)
-__attribute__((dllimport))
-extern char **environ;
-#endif
-
 /* Linux is behind the times a bit (also needs the *chdir_np functions) */
 #ifndef O_SEARCH
 #  define O_SEARCH O_PATH

--- a/winsup/testsuite/winsup.api/posix_spawn/errors.c
+++ b/winsup/testsuite/winsup.api/posix_spawn/errors.c
@@ -6,12 +6,6 @@
 #include <sys/stat.h>
 #include <unistd.h>
 
-/* Workaround for large relocation issue in binutils. */
-#if defined(__aarch64__)
-__attribute__((dllimport))	
-extern char **environ;
-#endif
-
 static char tmppath[] = "pspawn.XXXXXX";
 static const char exit0[] = "exit 0\n";
 

--- a/winsup/testsuite/winsup.api/posix_spawn/fds.c
+++ b/winsup/testsuite/winsup.api/posix_spawn/fds.c
@@ -7,12 +7,6 @@
 #include <string.h>
 #include <unistd.h>
 
-/* Workaround for large relocation issue in binutils. */
-#if defined(__aarch64__)
-__attribute__((dllimport))	
-extern char **environ;
-#endif
-
 int handle_child (char *devfd, char *target)
 {
   char buf[PATH_MAX];

--- a/winsup/testsuite/winsup.api/posix_spawn/signals.c
+++ b/winsup/testsuite/winsup.api/posix_spawn/signals.c
@@ -6,12 +6,6 @@
 #include <string.h>
 #include <unistd.h>
 
-/* Workaround for large relocation issue in binutils. */
-#if defined(__aarch64__)
-__attribute__((dllimport))	
-extern char **environ;
-#endif
-
 int handle_child (char *arg)
 {
   struct sigaction sa;

--- a/winsup/testsuite/winsup.api/posix_spawn/win32.c
+++ b/winsup/testsuite/winsup.api/posix_spawn/win32.c
@@ -9,12 +9,6 @@
 #include <sys/cygwin.h>
 #include <unistd.h>
 
-/* Workaround for large relocation issue in binutils. */
-#if defined(__aarch64__)
-__attribute__((dllimport))
-extern char **environ;
-#endif
-
 char * find_winchild (void)
 {
   static const char winchild[] = "/winchild";

--- a/winsup/utils/newgrp.c
+++ b/winsup/utils/newgrp.c
@@ -25,12 +25,6 @@ details. */
 
 #define PATH_PREFIX	"PATH=/usr/bin:"
 
-/* Workaround for large relocation issue in binutils. */
-#if defined(__aarch64__)
-__attribute__((dllimport))
-extern char **environ;
-#endif
-
 char *
 create_env_var (const char *name, const char *val)
 {


### PR DESCRIPTION
Validated by
https://github.com/Windows-on-ARM-Experiments/mingw-woarm64-build/pull/338
https://github.com/Windows-on-ARM-Experiments/mingw-woarm64-build/actions/runs/17958048642